### PR TITLE
action_invoker: add support for duplicate query param keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Resource Set Changelog
 
 ### master
 
+* Added support for duplicate query parameter keys
+  ([#9](https://github.com/kyrylo/resource_set/pull/9))
+
 ### [v1.0.1][v1.0.1] (September 8, 2017)
 
 * Fixed Ruby warnings ([#7](https://github.com/kyrylo/resource_set/pull/7))

--- a/lib/resource_set/action_invoker.rb
+++ b/lib/resource_set/action_invoker.rb
@@ -6,6 +6,10 @@ module ResourceSet
       @action = action
       @resource = resource
       @connection = resource.connection
+
+      # Support for duplicate query parameter keys.
+      @connection.options.params_encoder = Faraday::FlatParamsEncoder
+
       @args = args
       @options = args.last.kind_of?(Hash) ? args.last : {}
       @response = nil

--- a/spec/lib/resource_set/action_invoker_spec.rb
+++ b/spec/lib/resource_set/action_invoker_spec.rb
@@ -104,13 +104,17 @@ RSpec.describe ResourceSet::ActionInvoker do
 
     context 'for requests with query params' do
       it 'appends the query parameters to the endpoint' do
-        action.query_keys :per_page, :page
+        action.query_keys :per_page, :page, :name
         action.path '/paged'
 
-        result = ResourceSet::ActionInvoker.call(action, resource, page: 3, per_page: 300)
+        result = ResourceSet::ActionInvoker.call(
+          action, resource, page: 3, name: %w(foo bar)
+        )
         addressed = Addressable::URI.parse(result)
 
-        expect(addressed.query_values).to include('per_page' => '300', 'page' => '3')
+        expect(addressed.query_values(Array)).to eq(
+          [%w(name foo), %w(name bar), %w(page 3)]
+        )
       end
     end
 


### PR DESCRIPTION
Instead of passing an int or a string, pass an array with values.